### PR TITLE
Fix FluidFuelRegister addFuel from NBT

### DIFF
--- a/src/main/java/crazypants/enderio/fluid/FluidFuelRegister.java
+++ b/src/main/java/crazypants/enderio/fluid/FluidFuelRegister.java
@@ -106,7 +106,7 @@ public class FluidFuelRegister implements IFluidRegister {
     if(!tag.hasKey(KEY_TOTAL_BURN_TIME)) {
       return;
     }
-    addFuel(tag.getString(KEY_FLUID_NAME), tag.getInteger(KEY_FLUID_NAME), tag.getInteger(KEY_TOTAL_BURN_TIME));
+    addFuel(tag.getString(KEY_FLUID_NAME), tag.getInteger(KEY_POWER_PER_CYCLE), tag.getInteger(KEY_TOTAL_BURN_TIME));
   }
 
   public void addFuel(String fluidName, int powerPerCycleRF, int totalBurnTime) {


### PR DESCRIPTION
There is a typo in the NBT version of addFuel, so it was trying to get the "power per cycle" from the "fluid name" tag.
